### PR TITLE
fix : 처음화면 이동시 세트 구성이 남아있던 오류 수정

### DIFF
--- a/lib/view/payment/payment_success_screen.dart
+++ b/lib/view/payment/payment_success_screen.dart
@@ -5,7 +5,7 @@ import 'package:lottie/lottie.dart';
 import 'package:team_kiosk/core/constants/app_colors.dart';
 import 'package:team_kiosk/core/constants/theme_provider.dart';
 import 'package:team_kiosk/core/widgets/kiosk/category_card.dart';
-import 'package:team_kiosk/view/cart/cart_notifier.dart';
+import 'package:team_kiosk/view/set_builder/set_builder_notification.dart';
 
 class PaymentSuccessScreen extends ConsumerWidget {
   const PaymentSuccessScreen({super.key});
@@ -14,6 +14,7 @@ class PaymentSuccessScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.read(kioskThemeProvider);
     final textStyles = ref.read(textStyleSetProvider);
+    final setBuilderState = ref.watch(setBuilderProvider.notifier);
     return Scaffold(
       backgroundColor: theme.background,
       body: Column(
@@ -37,11 +38,16 @@ class PaymentSuccessScreen extends ConsumerWidget {
               padding: const EdgeInsets.all(16),
               child: CategoryCard(
                 icon: Icons.refresh,
-                category: theme == KioskTheme.fromMode(KioskMode.burger) ? Category.burger : Category.cafe,
+                category:
+                    theme == KioskTheme.fromMode(KioskMode.burger)
+                        ? Category.burger
+                        : Category.cafe,
                 theme: theme,
                 text: '처음으로',
                 onTap: () {
                   context.go('/');
+                  setBuilderState.selectSideMenu(name: '');
+                  setBuilderState.selectDrinkMenu(name: '');
                 },
               ),
             ),


### PR DESCRIPTION
## 📝 PR 제목
- [x] 제목은 한눈에 이해할 수 있게 작성
- [x] 커밋 메시지 규칙과 일치시키기 (feat, fix, chore 등)

## ✨ 작업 내용
- 결제 완료 후 처음 화면 이동 후 새로운 연습 할 때 기존의 사이드와 음료수 값이 남아있던 문제 수정 